### PR TITLE
Added pull_number inference from workflow_run event context

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -11,7 +11,6 @@ on:
       pull_number:
         description: 'The pull request number'
         required: false
-        default: '${{ github.event.workflow_run.pull_requests[0].number }}'
         type: string
       template:
         description: 'The template name or a lodash style template to use for the comment'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added `pull_number` inference from the `workflow_run` event context
+
+### Changed
+- Removed the default value for the `pull_number` input
 
 ## [1.0.2] - 2024-04-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
   cancel-in-progress: true
 
 jobs:
@@ -76,7 +76,7 @@ with:
   # The repository to comment on
   repository: '${{ github.repository }}'
   # The pull request number
-  pull_number: '${{ github.event.workflow_run.pull_requests[0].number }}'
+  pull_number: ''
   # The template name or a lodash style template to use for the comment
   template: 'sorted_by_result'
   # The identifier to use for the sticky comment

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,7 @@ inputs:
     default: '${{ github.repository }}'
   pull_number:
     description: 'The pull request number'
-    required: true
-    default: '${{ github.event.workflow_run.pull_requests[0].number }}'
+    required: false
   template:
     description: 'The template name or a lodash style template to use for the comment'
     required: false


### PR DESCRIPTION
Unfortunately, we cannot rely on the `pull_requests` array provided in the `workflow_run` event context because it doesn't contain PRs originating from forks. This PR replaces it with an issue search for the matching PR.